### PR TITLE
EMCB-109: impt log stream fails with HTTP/400 behind Proxy Server

### DIFF
--- a/lib/util/ImpCentralApiHelper.js
+++ b/lib/util/ImpCentralApiHelper.js
@@ -53,27 +53,29 @@ class ImpCentralApiHelper {
         this._authConfig = AuthConfig.getEntity(authLocation, accountId);
         this._impCentralApi = new ImpCentralApi(endpoint || this._authConfig.endpoint);
         this._entityStorage = new EntityStorage();
+        this._majorNodejsVersion = parseInt(process.version.slice(1).split('.')[0], 10);
+        this._httpProxy = null;
+        this._httpsProxy = null;
         this._setupProxyAgent();
     }
 
     _setupProxyAgent() {
-        let httpProxy = process.env.GLOBAL_AGENT_HTTP_PROXY || process.env.HTTP_PROXY || process.env.http_proxy;
-        let httpsProxy = process.env.GLOBAL_AGENT_HTTPS_PROXY || process.env.HTTPS_PROXY || process.env.https_proxy;
-        const majorNodejsVersion = parseInt(process.version.slice(1).split('.')[0], 10);
+        this._httpProxy = process.env.GLOBAL_AGENT_HTTP_PROXY || process.env.HTTP_PROXY || process.env.http_proxy;
+        this._httpsProxy = process.env.GLOBAL_AGENT_HTTPS_PROXY || process.env.HTTPS_PROXY || process.env.https_proxy;
         // global-agent module works for NodeJS v10+ only
-        if (majorNodejsVersion >= 10 && (httpProxy || httpsProxy)) {
+        if (this._majorNodejsVersion >= 10 && (this._httpProxy || this._httpsProxy)) {
             // global-agent module recognizes GLOBAL_AGENT_HTTP_PROXY/GLOBAL_AGENT_HTTPS_PROXY env vars
-            if (httpProxy) {
-                process.env.GLOBAL_AGENT_HTTP_PROXY = httpProxy;
+            if (this._httpProxy) {
+                process.env.GLOBAL_AGENT_HTTP_PROXY = this._httpProxy;
             }
-            if (httpsProxy) {
+            if (this._httpsProxy) {
                 // global-agent module accepts only "http:" value as proxy url protocol.
                 // In fact it uses the endpoint protocol to determine the type of connection and
                 // establishes https connection for impCentral endpoints.
-                if (httpsProxy.startsWith('https:')) {
-                    httpsProxy = 'http:' + httpsProxy.slice(6);
+                if (this._httpsProxy.startsWith('https:')) {
+                    this._httpsProxy = 'http:' + this._httpsProxy.slice(6);
                 }
-                process.env.GLOBAL_AGENT_HTTPS_PROXY = httpsProxy;
+                process.env.GLOBAL_AGENT_HTTPS_PROXY = this._httpsProxy;
             }
             GlobalAgent.bootstrap();
             // remove env vars to prevent double proxy handling by global-agent module and 
@@ -82,6 +84,13 @@ class ImpCentralApiHelper {
             delete process.env['https_proxy'];
             delete process.env['HTTP_PROXY'];
             delete process.env['http_proxy'];
+        }
+    }
+
+    _checkProxyAndNodeJSVersion() {
+        // global-agent module used for log streaming through proxy works for NodeJS v10+ only
+        if (this._majorNodejsVersion < 10 && (this._httpProxy || this._httpsProxy)) {
+            UserInteractor.printInfo(UserInteractor.MESSAGES.LOG_STREAM_THROUGH_PROXY, process.version);
         }
     }
 
@@ -499,6 +508,7 @@ class ImpCentralApiHelper {
     }
 
     logStream(deviceIds, messageHandler, stateChangeHandler = null, errorHandler = null) {
+        this._checkProxyAndNodeJSVersion();
         let logStreamId;
         const entityApi = this._impCentralApi.logStreams;
         return this._checkAccessToken().

--- a/lib/util/ImpCentralApiHelper.js
+++ b/lib/util/ImpCentralApiHelper.js
@@ -67,8 +67,9 @@ class ImpCentralApiHelper {
                 process.env.GLOBAL_AGENT_HTTP_PROXY = httpProxy;
             }
             if (httpsProxy) {
-                // global-agent module accepts only "http:" value as url protocol.
-                // In fact it works properly for https endpoints in this case.
+                // global-agent module accepts only "http:" value as proxy url protocol.
+                // In fact it uses the endpoint protocol to determine the type of connection and
+                // establishes https connection for impCentral endpoints.
                 if (httpsProxy.startsWith('https:')) {
                     httpsProxy = 'http:' + httpsProxy.slice(6);
                 }

--- a/lib/util/ImpCentralApiHelper.js
+++ b/lib/util/ImpCentralApiHelper.js
@@ -25,6 +25,7 @@
 'use strict';
 
 const Util = require('util');
+const GlobalAgent = require('global-agent');
 const ImpCentralApi = require('imp-central-api');
 const LogStreams = ImpCentralApi.LogStreams;
 const AuthConfig = require('./AuthConfig');
@@ -52,6 +53,35 @@ class ImpCentralApiHelper {
         this._authConfig = AuthConfig.getEntity(authLocation, accountId);
         this._impCentralApi = new ImpCentralApi(endpoint || this._authConfig.endpoint);
         this._entityStorage = new EntityStorage();
+        this._setupProxyAgent();
+    }
+
+    _setupProxyAgent() {
+        let httpProxy = process.env.GLOBAL_AGENT_HTTP_PROXY || process.env.HTTP_PROXY || process.env.http_proxy;
+        let httpsProxy = process.env.GLOBAL_AGENT_HTTPS_PROXY || process.env.HTTPS_PROXY || process.env.https_proxy;
+        const majorNodejsVersion = parseInt(process.version.slice(1).split('.')[0], 10);
+        // global-agent module works for NodeJS v10+ only
+        if (majorNodejsVersion >= 10 && (httpProxy || httpsProxy)) {
+            // global-agent module recognizes GLOBAL_AGENT_HTTP_PROXY/GLOBAL_AGENT_HTTPS_PROXY env vars
+            if (httpProxy) {
+                process.env.GLOBAL_AGENT_HTTP_PROXY = httpProxy;
+            }
+            if (httpsProxy) {
+                // global-agent module accepts only "http:" value as url protocol.
+                // In fact it works properly for https endpoints in this case.
+                if (httpsProxy.startsWith('https:')) {
+                    httpsProxy = 'http:' + httpsProxy.slice(6);
+                }
+                process.env.GLOBAL_AGENT_HTTPS_PROXY = httpsProxy;
+            }
+            GlobalAgent.bootstrap();
+            // remove env vars to prevent double proxy handling by global-agent module and 
+            // request/eventsource modules (as they recognize these env vars also)
+            delete process.env['HTTPS_PROXY'];
+            delete process.env['https_proxy'];
+            delete process.env['HTTP_PROXY'];
+            delete process.env['http_proxy'];
+        }
     }
 
     set debug(value) {

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -109,6 +109,7 @@ const MESSAGES = {
     LOG_STREAM_EXIT : 'Press <Ctrl-C> to exit.',
     LOG_STREAM_CLOSED : 'The log stream is closed.',
     LOG_STREAM_RECONNECT : 'The log stream is lost. Trying to reconnect...',
+    LOG_STREAM_THROUGH_PROXY : 'Logs streaming requires Node.js v10+ (current version is %s). Please upgrade Node.js.',
     DELETE_ENTITIES : 'The following entities will be deleted:',
     DELETE_DEVICES_UNASSIGNED : `The following ${_DEVICES} will be unassigned from ${_DEVICE_GROUPS}:`,
     DELETE_DEVICES_REMOVED : `The following ${_DEVICES} will be removed from the account:`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -207,6 +207,11 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.1.0.tgz",
       "integrity": "sha512-IWIbu7pMqyw3EAJHzzHbWa85b6oud/yfKYg5rqB5hNE8CeMi3nX+2C2sj0HswfblST86hpVEOAb9x34NZd6P7A=="
     },
+    "boolean": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.0.1.tgz",
+      "integrity": "sha512-HRZPIjPcbwAVQvOTxR4YE3o8Xs98NqbbL1iEZDCz7CL8ql0Lt5iOyJFxfnAB0oFs8Oh02F/lLlg30Mexv46LjA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -279,6 +284,11 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
+    "core-js": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
+      "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -340,6 +350,14 @@
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
       "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -349,6 +367,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "detect-node": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+      "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
     },
     "ecc-jsbn": {
       "version": "0.1.1",
@@ -367,6 +390,11 @@
         "once": "^1.4.0"
       }
     },
+    "es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
+    },
     "es6-promise": {
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
@@ -379,6 +407,11 @@
       "requires": {
         "es6-promise": "^4.0.3"
       }
+    },
+    "escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -486,6 +519,35 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "global-agent": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.1.8.tgz",
+      "integrity": "sha512-VpBe/rhY6Rw2VDOTszAMNambg+4Qv8j0yiTNDYEXXXxkUNGWLHp8A3ztK4YDBbFNcWF4rgsec6/5gPyryya/+A==",
+      "requires": {
+        "boolean": "^3.0.0",
+        "core-js": "^3.6.4",
+        "es6-error": "^4.1.1",
+        "matcher": "^2.1.0",
+        "roarr": "^2.15.2",
+        "semver": "^7.1.2",
+        "serialize-error": "^5.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+        }
+      }
+    },
+    "globalthis": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.1.tgz",
+      "integrity": "sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==",
+      "requires": {
+        "define-properties": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -735,6 +797,14 @@
         "p-defer": "^1.0.0"
       }
     },
+    "matcher": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.1.0.tgz",
+      "integrity": "sha512-o+nZr+vtJtgPNklyeUKkkH42OsK8WAfdgaJE2FNxcjLPg+5QbeEoT6vRj8Xq/iv18JlQ9cmKsEu0b94ixWf1YQ==",
+      "requires": {
+        "escape-string-regexp": "^2.0.0"
+      }
+    },
     "md5": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
@@ -813,6 +883,11 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "octokit-pagination-methods": {
       "version": "1.1.0",
@@ -1029,6 +1104,26 @@
         "path-parse": "^1.0.6"
       }
     },
+    "roarr": {
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.2.tgz",
+      "integrity": "sha512-jmaDhK9CO4YbQAV8zzCnq9vjAqeO489MS5ehZ+rXmFiPFFE6B+S9KYO6prjmLJ5A0zY3QxVlQdrIya7E/azz/Q==",
+      "requires": {
+        "boolean": "^3.0.0",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "dependencies": {
+        "sprintf-js": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+          "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -1043,6 +1138,19 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
+    },
+    "semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+    },
+    "serialize-error": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-5.0.0.tgz",
+      "integrity": "sha512-/VtpuyzYf82mHYTtI4QKtwHa79vAdU5OQpNPAmE/0UDdlGT0ZxHwC+J6gXkw29wwoVI8fMPsfcVHOwXtUQYYQA==",
+      "requires": {
+        "type-fest": "^0.8.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1141,6 +1249,11 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
     },
     "universal-user-agent": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "dateformat": "^3.0.3",
     "deepmerge": "^3.2.0",
     "glob": "^7.1.3",
+    "global-agent": "^2.1.8",
     "hoek": "^6.0.2",
     "imp-central-api": "^1.5.0",
     "lodash": "^4.17.11",


### PR DESCRIPTION
Fixes https://github.com/EatonGMBD/imp-central-impt/issues/4 (`impt log stream` fails with HTTP/400 behind Proxy Server).

eventsource module, which is used for logs streaming, doesn't process requests through some of the proxies.
As a workaround global-agent module is additionally used now (only for the case with the proxy).
It substitutes functionality which processes http/https requests and works correctly through the proxy.
Verified that https connection is established between impt and a proxy.

Important notes:
- NodeJS version 10+ is required (successfully tested with NodeJS v10 and v12)
- Successfully tested with several proxies but not with the Eaton's one. Please verify with the Eaton's proxy.
- global-agent module license is BSD-3-Clause