### PR TITLE
EMCB-111: Allow multiple devices in impt device assign

### DIFF
--- a/CommandsManual.md
+++ b/CommandsManual.md
@@ -865,16 +865,16 @@ impt device assign [--account <account_id>] --device <DEVICE_IDENTIFIER> [--dg <
     [--confirmed] [--output <mode>] [--help]
 ```
 
-Assigns the specified device to the specified Device Group. Fails if the specified Device Group does not exist.
+Assigns the specified devices to the specified Device Group. Fails if the specified Device Group does not exist.
 
-The user is asked to confirm the operation if the specified Device is already assigned to another Device Group. If the operation is confirmed (manually or automatically with the `--confirmed` option), the device is reassigned to the new Device Group.
+The user is asked to confirm the operation if a specified device is already assigned to another Device Group. If the operation is confirmed (manually or automatically with the `--confirmed` option), the device is reassigned to the new Device Group.
 
-The operation may fail for some combinations of Device Group [types](#device-group-type), for some kinds of device, or operations such as reassigning across Products.
+The operation may fail for some combinations of Device Group [types](#device-group-type), for some kinds of device, or operations such as reassigning across Products. It is not an atomic operation - it is possible for some of the specified devices to be assigned and other devices to fail to be assigned.
 
 | Option | Alias | Mandatory? | Value Required? | Description |
 | --- | --- | --- | --- | --- |
 | --account | -ac | No | Yes | The authenticated account identifier: an account ID |
-| --device | -d | Yes | Yes | A [device identifier](#device-identifier) |
+| --device | -d | Yes | Yes | The [device identifier](#device-identifier) of Device to be assigned. This option may be repeated multiple times to specify multiple Devices |
 | --dg | -g | Yes/[Project](#project-files) | Yes | A [Device Group identifier](#device-group-identifier). If not specified, the Device Group referenced by the [Project Files](#project-files) in the current directory is used (if there is no Project file, the command fails) |
 | --confirmed | -q | No | No | Executes the operation without asking additional confirmation from user |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
@@ -968,12 +968,14 @@ Reboots the specified device and, optionally, starts displaying logs from it.
 impt device unassign [--account <account_id>] --device <DEVICE_IDENTIFIER> [--unbond <unbond_key>] [--output <mode>] [--help]
 ```
 
-Unassigns the specified device. Does nothing if the device already unassigned.
+Unassigns the specified devices. Does nothing if a device is already unassigned.
+
+It is not an atomic operation — it is possible for some of the specified devices to be unassigned and other devices to fail to be unassigned.
 
 | Option | Alias | Mandatory? | Value Required? | Description |
 | --- | --- | --- | --- | --- |
 | --account | -ac | No | Yes | The authenticated account identifier: an account ID |
-| --device | -d | Yes | Yes | A [device identifier](#device-identifier) |
+| --device | -d | Yes | Yes | The [device identifier](#device-identifier) of Device to be unassigned. This option may be repeated multiple times to specify multiple Devices |
 | --unbond | -u | No | Yes | An unbond key is required to unassign the specified device from a Device Group of the *production* [type](#device-group-type) |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
 | --help | -h | No | No | Displays a description of the command. Ignores any other options |

--- a/bin/cmds/device/assign.js
+++ b/bin/cmds/device/assign.js
@@ -39,7 +39,11 @@ exports.describe = COMMAND_SHORT_DESCR;
 exports.builder = function (yargs) {
     const options = Options.getOptions({
         [Options.ACCOUNT] : false,
-        [Options.DEVICE_IDENTIFIER] : true,
+        [Options.DEVICE_IDENTIFIER] : {
+            demandOption : true,
+            type : 'array',
+            elemType : 'string'
+        },
         [Options.DEVICE_GROUP_IDENTIFIER] : false,
         [Options.CONFIRMED] : false,
         [Options.OUTPUT] : false

--- a/bin/cmds/device/unassign.js
+++ b/bin/cmds/device/unassign.js
@@ -39,7 +39,11 @@ exports.describe = COMMAND_SHORT_DESCR;
 exports.builder = function (yargs) {
     const options = Options.getOptions({
         [Options.ACCOUNT] : false,
-        [Options.DEVICE_IDENTIFIER] : true,
+        [Options.DEVICE_IDENTIFIER] : {
+            demandOption : true,
+            type : 'array',
+            elemType : 'string'
+        },
         [Options.UNBOND] : false,
         [Options.OUTPUT] : false
     });

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -34,6 +34,7 @@ const Identifier = require('./util/Identifier');
 const Entity = require('./util/Entity');
 const Errors = require('./util/Errors');
 const Options = require('./util/Options');
+const Utils = require('./util/Utils');
 const Product = require('./Product');
 const DeviceGroup = require('./DeviceGroup');
 const Account = require('./Account');
@@ -220,10 +221,10 @@ class Device extends Entity {
             catch(error => UserInteractor.processError(error));
     }
 
-    assignToDG(deviceGroup) {
-        return this._helper.assignDevices(deviceGroup.id, this.id).
+    assignToDG(deviceGroup, devices) {
+        return this._helper.assignDevices(deviceGroup.id, ...devices.map(device => device.id)).
             then(() => UserInteractor.printInfo(UserInteractor.MESSAGES.DEVICE_ASSIGNED_TO_DG,
-                this.identifierInfo, deviceGroup.identifierInfo))
+                UserInteractor.getMultipleEntitiesInfo(devices), deviceGroup.identifierInfo))
             .catch(error => UserInteractor.processError(error));
     }
 
@@ -237,19 +238,26 @@ class Device extends Entity {
     // Returns:                 Nothing
     assign(options) {
         const deviceGroup = new DeviceGroup(options);
-        this.getEntity().
+        let devices = options.deviceIdentifier.map(deviceId => new Device().initByIdentifier(deviceId));
+        this._helper.makeConcurrentOperations(devices, device => device.getEntity()).
             then(() => deviceGroup.getEntity()).
             then(() => {
-                if (this.relatedDeviceGroupId === deviceGroup.id) {
-                    UserInteractor.printInfo(UserInteractor.MESSAGES.DEVICE_ALREADY_ASSIGNED_TO_DG,
-                        this.identifierInfo, deviceGroup.identifierInfo);
+                devices = Utils.getUniqueEntities(devices);
+                if (devices.every(device => device.relatedDeviceGroupId === deviceGroup.id)) {
+                    UserInteractor.printInfo(
+                        UserInteractor.MESSAGES.DEVICE_ALREADY_ASSIGNED_TO_DG,
+                        UserInteractor.getMultipleEntitiesInfo(devices),
+                        deviceGroup.identifierInfo);
                 }
                 else {
+                    devices = devices.filter(device => device.relatedDeviceGroupId !== deviceGroup.id);
+                    const reassignedDevices = devices.filter(device => device.assigned);
                     return UserInteractor.processCancelContinueChoice(
-                        Util.format(UserInteractor.MESSAGES.DEVICE_REASSIGN, this.identifierInfo, deviceGroup.identifierInfo),
+                        Util.format(UserInteractor.MESSAGES.DEVICE_REASSIGN, 
+                            UserInteractor.getMultipleEntitiesInfo(reassignedDevices), deviceGroup.identifierInfo),
                         this.assignToDG.bind(this),
-                        [deviceGroup],
-                        options.confirmed || !this.assigned);
+                        [deviceGroup, devices],
+                        options.confirmed || reassignedDevices.length === 0);
                 }
             }).
             then(() => UserInteractor.printResultWithStatus()).
@@ -263,16 +271,41 @@ class Device extends Entity {
     //
     // Returns:                 Promise that resolves when the Device(s) are successfully
     //                          unassigned, or rejects with an error
-    _unassign(options) {
-        return this.getEntity().then(() => {
-            if (this.assigned) {
-                return this._helper.unassignDevices(this.relatedDeviceGroupId, options.unbond, this.id).
-                    then(() => UserInteractor.printInfo(UserInteractor.MESSAGES.DEVICE_UNASSIGNED, this.identifierInfo));
-            }
-            else {
-                UserInteractor.printInfo(UserInteractor.MESSAGES.DEVICE_ALREADY_UNASSIGNED, this.identifierInfo);
-            }
-        });
+    _unassign(devices, options, errorHandler = null) {
+        return this._helper.makeConcurrentOperations(devices, device => device.getEntity()).
+            then(() => {
+                devices = Utils.getUniqueEntities(devices);
+                const deviceGroupsDevices = {};
+                for (let device of devices) {
+                    const deviceGroupId = device.relatedDeviceGroupId ? device.relatedDeviceGroupId : '';
+                    if (deviceGroupsDevices[deviceGroupId] === undefined) {
+                        deviceGroupsDevices[deviceGroupId] = [];
+                    }
+                    deviceGroupsDevices[deviceGroupId].push(device);
+                }
+                return this._helper.makeConcurrentOperations(Object.keys(deviceGroupsDevices),
+                    (deviceGroupId) => {
+                        const dgDevices = deviceGroupsDevices[deviceGroupId];
+                        if (deviceGroupId) {
+                            return this._helper.unassignDevices(deviceGroupId, options.unbond, ...dgDevices.map(device => device.id)).
+                                then(() => UserInteractor.printInfo(
+                                    UserInteractor.MESSAGES.DEVICE_UNASSIGNED,
+                                    UserInteractor.getMultipleEntitiesInfo(dgDevices))).
+                                catch(error => {
+                                    if (errorHandler) {
+                                        errorHandler(error, dgDevices);
+                                    } else {
+                                        throw error;
+                                    }
+                                });
+                        } else {
+                            UserInteractor.printInfo(
+                                UserInteractor.MESSAGES.DEVICE_ALREADY_UNASSIGNED,
+                                UserInteractor.getMultipleEntitiesInfo(dgDevices));
+                            return Promise.resolve();
+                        }
+                    });
+            });
     }
 
     // Unassigns the specified Device. Does nothing if the Device already unassigned.
@@ -282,7 +315,8 @@ class Device extends Entity {
     //
     // Returns:                 Nothing
     unassign(options) {
-        this._unassign(options).
+        const devices = options.deviceIdentifier.map(deviceId => new Device().initByIdentifier(deviceId));
+        this._unassign(devices, options).
             then(() => UserInteractor.printResultWithStatus()).
             catch(error => UserInteractor.processError(error));
     }

--- a/lib/Log.js
+++ b/lib/Log.js
@@ -31,6 +31,7 @@ const UserInteractor = require('./util/UserInteractor');
 const ProjectConfig = require('./util/ProjectConfig');
 const Identifier = require('./util/Identifier');
 const Errors = require('./util/Errors');
+const Utils = require('./util/Utils');
 const DeviceGroup = require('./DeviceGroup');
 const Device = require('./Device');
 const Colors = require('colors/safe');
@@ -212,9 +213,8 @@ class Log {
         }
         else {
             return this._helper.makeConcurrentOperations(devices, (device) => device.getEntityId()).then(() => {
+                devices = Utils.getUniqueEntities(devices);
                 this._deviceIds = devices.map(device => device.id);
-                // remove duplicates from _deviceIds
-                this._deviceIds = [...new Set(this._deviceIds)];
                 return this._helper.logStream(
                     this._deviceIds,
                     this._messageHandler.bind(this),
@@ -224,12 +224,9 @@ class Log {
                         this._logStreamId = logStreamId;
                         this._reconnecting = false;
                         UserInteractor.spinnerStop();
-                        let deviceIds = this._deviceIds;
-                        if (deviceIds.length > UserInteractor.PRINTED_ENTITIES_LIMIT) {
-                            deviceIds = deviceIds.slice(0, UserInteractor.PRINTED_ENTITIES_LIMIT);
-                            deviceIds.push('...');
-                        }
-                        UserInteractor.printInfo(UserInteractor.MESSAGES.LOG_STREAM_OPENED, deviceIds.join(', '));
+                        UserInteractor.printInfo(
+                            UserInteractor.MESSAGES.LOG_STREAM_OPENED, 
+                            UserInteractor.getMultipleEntitiesInfo(devices));
                         UserInteractor.printSuccessStatus();
                         UserInteractor.printInfo('');
                         UserInteractor.printInfo(UserInteractor.MESSAGES.LOG_STREAM_EXIT);

--- a/lib/util/DeleteHelper.js
+++ b/lib/util/DeleteHelper.js
@@ -187,10 +187,8 @@ class DeleteHelper {
     }
 
     _unassignDevices() {
-        return this._helper.makeConcurrentOperations(
-            this._summary.assignedDevices,
-            (device) => device._unassign({}),
-            this._onDeviceAlreadyUnassignedError.bind(this));
+        const Device = require('../Device');
+        return new Device()._unassign(this._summary.assignedDevices, {}, this._onDeviceAlreadyUnassignedError.bind(this));
     }
 
     _unflagBuilds() {
@@ -260,9 +258,11 @@ class DeleteHelper {
         }
     }
 
-    _onDeviceAlreadyUnassignedError(error, device) {
+    _onDeviceAlreadyUnassignedError(error, devices) {
         if (error instanceof Errors.EntityNotFoundError || this._helper.isMultipleEntitiesNotFoundError(error)) {
-            UserInteractor.printInfo(UserInteractor.MESSAGES.DEVICE_ALREADY_UNASSIGNED, device.identifierInfo);
+            UserInteractor.printInfo(
+                UserInteractor.MESSAGES.DEVICE_ALREADY_UNASSIGNED,
+                UserInteractor.getMultipleEntitiesInfo(devices));
         }
         else {
             throw error;

--- a/lib/util/TestSession.js
+++ b/lib/util/TestSession.js
@@ -81,7 +81,7 @@ class TestSession extends EventEmitter {
                 // The core issue is that if you restart the device, it might result
                 // in the agent running the OLD code, while device recieving the new one!
                 // This results in intermittent test failures.
-                device.assignToDG(deviceGroup);
+                device.assignToDG(deviceGroup, [ device ]);
 
                 // TODO: this doesn't work, so comment it out (temporary?)
                 // this._start(device);

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -91,13 +91,13 @@ const MESSAGES = {
     DG_NO_FLAGGED_BUILDS : `No "flagged" ${_DEPLOYMENTS} are found for %s.`,
     DG_NO_BUILDS_TO_DELETE : `No ${_DEPLOYMENTS} that can be deleted are found for %s.`,
     DG_MIN_SUPPORTED_DEPLOYMENT_UPDATED : `${_MIN_SUPPORTED_DEPLOYMENT} for %s is updated successfully.`,
-    DEVICE_ASSIGNED_TO_DG : '%s is assigned successfully to %s.',
-    DEVICE_ALREADY_ASSIGNED_TO_DG : '%s is already assigned to %s.',
-    DEVICE_REASSIGN : `%s is assigned to another ${_DEVICE_GROUP}. It will be reassigned to %s.`,
+    DEVICE_ASSIGNED_TO_DG : '%s are assigned successfully to %s.',
+    DEVICE_ALREADY_ASSIGNED_TO_DG : '%s are already assigned to %s.',
+    DEVICE_REASSIGN : `%s are assigned to another ${_DEVICE_GROUP}. They will be reassigned to %s.`,
     DEVICE_RESTARTED : 'Restart request for %s is successful.',
     DEVICE_COND_RESTARTED : 'Conditional restart request for %s is successful.',
-    DEVICE_UNASSIGNED : '%s is unassigned successfully.',
-    DEVICE_ALREADY_UNASSIGNED : '%s is already unassigned.',
+    DEVICE_UNASSIGNED : '%s are unassigned successfully.',
+    DEVICE_ALREADY_UNASSIGNED : '%s are already unassigned.',
     BUILD_COPIED : '%s is copied successfully to %s.',
     BUILD_DOWNLOADED : '%s source file(s) are downloaded successfully.',
     BUILD_SOURCE_FILES_EXIST : 'Source file(s) %s already exist. They will be overwritten.',
@@ -105,7 +105,7 @@ const MESSAGES = {
     BUILD_DEPLOY_FILE_NOT_SPECIFIED : '--%s option is not specified, empty %s code will be deployed.',
     LOG_GET_NEXT : 'Press <Enter> to see more logs or <Ctrl-C> to exit.',
     LOG_GET_FINISHED : 'No more logs are available.',
-    LOG_STREAM_OPENED : `Log stream for ${_DEVICE}(s) %s is opened.`,
+    LOG_STREAM_OPENED : 'Log stream for %s is opened.',
     LOG_STREAM_EXIT : 'Press <Ctrl-C> to exit.',
     LOG_STREAM_CLOSED : 'The log stream is closed.',
     LOG_STREAM_RECONNECT : 'The log stream is lost. Trying to reconnect...',
@@ -391,6 +391,22 @@ class UserInteractor {
         if (UserInteractor.isOutputLevelInfoEnabled()) {
             UserInteractor._printMessage(message, ...args);
         }
+    }
+
+    static getMultipleEntitiesInfo(entities) {
+        if (entities.length > 0) {
+            let printedEntities = entities;
+            let truncate = printedEntities.length > UserInteractor.PRINTED_ENTITIES_LIMIT;
+            if (truncate) {
+                printedEntities = printedEntities.slice(0, UserInteractor.PRINTED_ENTITIES_LIMIT);
+            }
+            printedEntities = printedEntities.map(entity => Util.format('"%s"', entity._identifier.info));
+            if (truncate) {
+                printedEntities.push('...');
+            }
+            return Util.format('%s(s) %s', entities[0].entityType, printedEntities.join(', '));
+        }
+        return '';
     }
 
     static printObjectInfo(object) {

--- a/lib/util/Utils.js
+++ b/lib/util/Utils.js
@@ -154,6 +154,19 @@ class Utils {
             throw new Errors.FileError(dirName, error.message);
         }
     }
+
+    static getUniqueEntities(entities) {
+        const uniqueIds = new Set();
+        const result = [];
+        for (let entity of entities) {
+            if (uniqueIds.has(entity.id)) {
+                continue;
+            }
+            uniqueIds.add(entity.id);
+            result.push(entity);
+        }
+        return result;
+    }
 }
 
 module.exports = Utils;

--- a/spec/device/device_assign.spec.js
+++ b/spec/device/device_assign.spec.js
@@ -90,7 +90,7 @@ ImptTestHelper.OUTPUT_MODES.forEach((outputMode) => {
         function _checkAlreadyAssignedDeviceMessage(commandOut, device, dg) {
             ImptTestHelper.checkOutputMessage(`${outputMode}`, commandOut,
                 Util.format(`${UserInterractor.MESSAGES.DEVICE_ALREADY_ASSIGNED_TO_DG}`,
-                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE} "${device}"`,
+                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE}(s) "${device}"`,
                     `${Identifier.ENTITY_TYPE.TYPE_DEVICE_GROUP} "${dg}"`)
             );
         }
@@ -99,7 +99,7 @@ ImptTestHelper.OUTPUT_MODES.forEach((outputMode) => {
         function _checkSuccessAssignedDeviceMessage(commandOut, device, dg) {
             ImptTestHelper.checkOutputMessage(`${outputMode}`, commandOut,
                 Util.format(`${UserInterractor.MESSAGES.DEVICE_ASSIGNED_TO_DG}`,
-                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE} "${device}"`,
+                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE}(s) "${device}"`,
                     `${Identifier.ENTITY_TYPE.TYPE_DEVICE_GROUP} "${dg}"`)
             );
         }
@@ -149,6 +149,18 @@ ImptTestHelper.OUTPUT_MODES.forEach((outputMode) => {
                         _checkAlreadyAssignedDeviceMessage(commandOut, config.devices[config.deviceidx], dg_id);
                         ImptTestHelper.checkSuccessStatus(commandOut);
                     })).
+                    then(_checkAssignDevice).
+                    then(done).
+                    catch(error => done.fail(error));
+            });
+
+            it('device assign multiple devices to dg', (done) => {
+                const devices = Array(3).fill(config.devices[config.deviceidx]).
+                    map((device) => `-d ${device}`).join(' ');
+                ImptTestHelper.runCommand(`impt device assign ${devices} -g ${dg_id} -q ${outputMode}`, (commandOut) => {
+                    _checkSuccessAssignedDeviceMessage(commandOut, config.devices[config.deviceidx], dg_id);
+                    ImptTestHelper.checkSuccessStatus(commandOut);
+                }).
                     then(_checkAssignDevice).
                     then(done).
                     catch(error => done.fail(error));

--- a/spec/device/device_unassign.spec.js
+++ b/spec/device/device_unassign.spec.js
@@ -79,7 +79,7 @@ ImptTestHelper.OUTPUT_MODES.forEach((outputMode) => {
         function _checkSuccessUnassignedDeviceMessage(commandOut, device) {
             ImptTestHelper.checkOutputMessage(`${outputMode}`, commandOut,
                 Util.format(`${UserInterractor.MESSAGES.DEVICE_UNASSIGNED}`,
-                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE} "${device}"`)
+                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE}(s) "${device}"`)
             );
         }
 
@@ -87,7 +87,7 @@ ImptTestHelper.OUTPUT_MODES.forEach((outputMode) => {
         function _checkAlreadyUnassignedDeviceMessage(commandOut, device) {
             ImptTestHelper.checkOutputMessage(`${outputMode}`, commandOut,
                 Util.format(`${UserInterractor.MESSAGES.DEVICE_ALREADY_UNASSIGNED}`,
-                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE} "${device}"`)
+                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE}(s) "${device}"`)
             );
         }
 
@@ -148,9 +148,21 @@ ImptTestHelper.OUTPUT_MODES.forEach((outputMode) => {
                     then(done).
                     catch(error => done.fail(error));
             });
+
+            it('unassign multiple devices', (done) => {
+                const devices = Array(3).fill(config.devices[config.deviceidx]).
+                    map((device) => `-d ${device}`).join(' ');
+                ImptTestHelper.runCommand(`impt device unassign ${devices} ${outputMode}`, (commandOut) => {
+                    _checkSuccessUnassignedDeviceMessage(commandOut, config.devices[config.deviceidx]);
+                    ImptTestHelper.checkSuccessStatus(commandOut);
+                }).
+                    then(() => _checkUnassignDevice).
+                    then(done).
+                    catch(error => done.fail(error));
+            });
         });
 
-        describe('device unassign positive tests >', () => {
+        describe('device unassign negative tests >', () => {
             it('unassign not exist device', (done) => {
                 ImptTestHelper.runCommand(`impt device unassign -d not-exist-device ${outputMode}`, (commandOut) => {
                     MessageHelper.checkEntityNotFoundError(commandOut, MessageHelper.DEVICE, 'not-exist-device');

--- a/spec/log/log_stream.spec.js
+++ b/spec/log/log_stream.spec.js
@@ -76,7 +76,7 @@ ImptTestHelper.OUTPUT_MODES.forEach((outputMode) => {
         function _checkLogStreamOpenedMessage(commandOut, device) {
             ImptTestHelper.checkOutputMessage(`${outputMode}`, commandOut,
                 Util.format(`${UserInterractor.MESSAGES.LOG_STREAM_OPENED}`,
-                    `${device}`
+                    `${Identifier.ENTITY_TYPE.TYPE_DEVICE}(s) "${device}"`
                 )
             );
         }


### PR DESCRIPTION
Fixes https://github.com/EatonGMBD/imp-central-impt/issues/7 (Allow multiple device IDs in `impt device assign`)

--device (-d) option of `impt device assign` and `impt device unassign` commands may be repeated several times to specify multiple devices.
For example, `impt device assign -d 30000c2a690e1c66 -d 30000c2a690e1cf6 -d 30000c2a690e1ada --dg test_dg`

The details are described in CommandsManual.md.