### PR TITLE
EMCB-114: Adding link to error output

### DIFF
--- a/lib/Build.js
+++ b/lib/Build.js
@@ -239,8 +239,8 @@ class Build extends Entity {
                     } else {
                         projectBuilder = this._projectConfig.builderJSON;
                     }
-        
-                    // Buidler variables in secrets file
+
+                    // Builder variables in secrets file
                     if (this._projectConfig.localProjectSecrets) {
                         secretBuilder = deepmerge(this._projectConfig.globalProjectSecrets, this._projectConfig.localProjectSecrets);
                     } else {
@@ -310,7 +310,7 @@ class Build extends Entity {
                     this.renameSaveFiles(this._displayData.Deployment.id)
                     UserInteractor.printResultWithStatus(this._displayData)
                 }).
-                catch(error => UserInteractor.processError(error));
+                catch(error => UserInteractor.processError(error, this._agentFileName, this._deviceFileName));
         }
     }
 
@@ -343,7 +343,9 @@ class Build extends Entity {
                     UserInteractor.printResultWithStatus();
                 }
             }).
-            catch(error => UserInteractor.processError(error));
+            catch(error => {
+                    UserInteractor.processError(error, this._agentFileName, this._deviceFileName)
+                });
         }
     }
 

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -607,7 +607,8 @@ class UserInteractor {
 
             entities.forEach((entity) => {
                 if (['title', 'detail', 'status'].every(prop => entity.hasOwnProperty(prop))) {
-                    if(entity.title === "Compilation Error" && Array.isArray(entity.meta)) {
+                    if(entity.title === "Compilation Error" && Array.isArray(entity.meta) &&
+                       typeof agentFileName !== 'undefined' && typeof deviceFileName !== 'undefined') {
                         entity.meta.forEach((meta) => {
                             var file = meta.file === "agent_code" ? agentFileName : deviceFileName;
                             if(typeof meta.row === 'number' && typeof meta.column === 'number')

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -607,14 +607,15 @@ class UserInteractor {
 
             entities.forEach((entity) => {
                 if (['title', 'detail', 'status'].every(prop => entity.hasOwnProperty(prop))) {
-
-                    if(entity.title === "Compilation Error"){
+                    if(entity.title === "Compilation Error" && Array.isArray(entity.meta)) {
                         entity.meta.forEach((meta) => {
-                            var file = meta.file === "agent_code" ? agentFileName : deviceFileName
-                            UserInteractor._printMessage(file + ":" + meta.row + ":" + meta.column)
-                      })
+                            var file = meta.file === "agent_code" ? agentFileName : deviceFileName;
+                            if(typeof meta.row === 'number' && typeof meta.column === 'number')
+                                UserInteractor._printMessage(file + ":" + meta.row + ":" + meta.column);
+                            else
+                                UserInteractor._printMessage(file);
+                        });
                     }
-
                     const message = entity.title + ': ' + entity.detail;
                     if (UserInteractor._isError(entity)) {
                         UserInteractor.printError(message);

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -481,7 +481,7 @@ class UserInteractor {
         }
     }
 
-    static processError(error) {
+    static processError(error, agentFileName, deviceFileName) {
         UserInteractor.spinnerStop();
         if (UserInteractor.isOutputLevelDebugEnabled()) {
             UserInteractor._printMessage(error);
@@ -568,7 +568,7 @@ class UserInteractor {
             UserInteractor.printErrorStatus();
         }
         else if (error instanceof ImpCentralApi.Errors.ImpCentralApiError) {
-            UserInteractor.printImpCentralApiError(error);
+            UserInteractor.printImpCentralApiError(error, agentFileName, deviceFileName);
             UserInteractor.printErrorStatus();
         }
         else if (error instanceof ImpCentralApi.Errors.InvalidDataError) {
@@ -586,9 +586,9 @@ class UserInteractor {
         }
     }
 
-    static printImpCentralApiError(error) {
+    static printImpCentralApiError(error, agentFileName, deviceFileName) {
         if (UserInteractor.isOutputText() && error.body && error.body.hasOwnProperty('errors')) {
-            UserInteractor._printErrorsAndWarnings(error.body.errors);
+            UserInteractor._printErrorsAndWarnings(error.body.errors, agentFileName, deviceFileName);
         }
         else {
             UserInteractor.printError(error.message);
@@ -602,10 +602,19 @@ class UserInteractor {
         }
     }
 
-    static _printErrorsAndWarnings(entities) {
+    static _printErrorsAndWarnings(entities, agentFileName, deviceFileName) {
         if (Array.isArray(entities)) {
+
             entities.forEach((entity) => {
                 if (['title', 'detail', 'status'].every(prop => entity.hasOwnProperty(prop))) {
+
+                    if(entity.title === "Compilation Error"){
+                        entity.meta.forEach((meta) => {
+                            var file = meta.file === "agent_code" ? agentFileName : deviceFileName
+                            UserInteractor._printMessage(file + ":" + meta.row + ":" + meta.column)
+                      })
+                    }
+
                     const message = entity.title + ': ' + entity.detail;
                     if (UserInteractor._isError(entity)) {
                         UserInteractor.printError(message);

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -607,11 +607,11 @@ class UserInteractor {
 
             entities.forEach((entity) => {
                 if (['title', 'detail', 'status'].every(prop => entity.hasOwnProperty(prop))) {
-                    if(entity.title === "Compilation Error" && Array.isArray(entity.meta) &&
-                       typeof agentFileName !== 'undefined' && typeof deviceFileName !== 'undefined') {
+                    if (entity.title === "Compilation Error" && Array.isArray(entity.meta) &&
+                        (typeof agentFileName !== 'undefined' || typeof deviceFileName !== 'undefined')) {
                         entity.meta.forEach((meta) => {
                             var file = meta.file === "agent_code" ? agentFileName : deviceFileName;
-                            if(typeof meta.row === 'number' && typeof meta.column === 'number')
+                            if (typeof meta.row === 'number' && typeof meta.column === 'number')
                                 UserInteractor._printMessage(file + ":" + meta.row + ":" + meta.column);
                             else
                                 UserInteractor._printMessage(file);


### PR DESCRIPTION
This PR provides an update that allows for impt build run squirrel compilation errors to be clickable in VSCode via \<path\>:\<line\>:\<column\> (with several limitations which depend on a platform).
This \<path\>:\<line\>:\<column\> template is printed only for "impt build run" command, not for "impt test run", because in this case squirrel file is being preprocessed and the \<line\> position in preprocessed squirrel file does not correspond with \<line\> position in original file. 