### PR TITLE
EMCB-180: Allow multiple devices IDs in impt device remove

### DIFF
--- a/CommandsManual.md
+++ b/CommandsManual.md
@@ -930,16 +930,18 @@ The returned list of the devices may be filtered. Filtering uses any combination
 impt device remove [--account <account_id>] --device <DEVICE_IDENTIFIER> [--force] [--confirmed] [--output <mode>] [--help]
 ```
 
-Removes the specified Device from the current account.
+Removes the specified Devices from the current account.
 
-The command fails if the device is assigned to a Device Group and the `--force` option is not specified. Use either `--force` or [`impt device unassign`](#device-unassign) to unassign the device before removal.
+The command fails if a device is assigned to a Device Group and the `--force` option is not specified. Use either `--force` or [`impt device unassign`](#device-unassign) to unassign devices before removal.
 
 The user is asked to confirm the operation, unless confirmed automatically with the `--confirmed` option.
+
+It is not an atomic operation - it is possible for some of the specified devices to be removed and other devices to fail to be removed.
 
 | Option | Alias | Mandatory? | Value Required? | Description |
 | --- | --- | --- | --- | --- |
 | --account | -ac | No | Yes | The authenticated account identifier: an account ID |
-| --device | -d | Yes | Yes | A [device identifier](#device-identifier) |
+| --device | -d | Yes | Yes | A [device identifier](#device-identifier) of Device to be removed. This option may be repeated multiple times to specify multiple Devices |
 | --force | -f | No | No | If the device is assigned to a Device Group, unassign it first |
 | --confirmed | -q | No | No | Executes the operation without asking additional confirmation from user |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |

--- a/bin/cmds/device/remove.js
+++ b/bin/cmds/device/remove.js
@@ -39,7 +39,11 @@ exports.describe = COMMAND_SHORT_DESCR;
 exports.builder = function (yargs) {
     const options = Options.getOptions({
         [Options.ACCOUNT] : false,
-        [Options.DEVICE_IDENTIFIER] : true,
+        [Options.DEVICE_IDENTIFIER] : {
+            demandOption : true,
+            type : 'array',
+            elemType : 'string'
+        },
         [Options.FORCE] : false,
         [Options.CONFIRMED] : false,
         [Options.OUTPUT] : false
@@ -55,5 +59,5 @@ exports.builder = function (yargs) {
 
 exports.handler = function (argv) {
     const options = new Options(argv);
-    new Device(options).delete(options);
+    new Device(options).remove(options);
 };

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -29,6 +29,7 @@ const ImpCentralApi = require('imp-central-api');
 const Devices = ImpCentralApi.Devices;
 const ImpCentralApiHelper = require('./util/ImpCentralApiHelper');
 const ListHelper = require('./util/ListHelper');
+const DeleteHelper = require('./util/DeleteHelper');
 const UserInteractor = require('./util/UserInteractor');
 const Identifier = require('./util/Identifier');
 const Entity = require('./util/Entity');
@@ -317,6 +318,23 @@ class Device extends Entity {
     unassign(options) {
         const devices = options.deviceIdentifier.map(deviceId => new Device().initByIdentifier(deviceId));
         this._unassign(devices, options).
+            then(() => UserInteractor.printResultWithStatus()).
+            catch(error => UserInteractor.processError(error));
+    }
+
+    // Removes the specified Devices from the current account.
+    //
+    // Parameters:
+    //     options : Options    impt options of the corresponding command
+    //
+    // Returns:                 Nothing
+    remove(options) {
+        let devices = options.deviceIdentifier.map(deviceId => new Device().initByIdentifier(deviceId));
+        this._helper.makeConcurrentOperations(devices, device => device.getEntity()).
+            then(() => {
+                devices = Utils.getUniqueEntities(devices);
+                return new DeleteHelper().processDeleteEntities(devices, options);
+            }).
             then(() => UserInteractor.printResultWithStatus()).
             catch(error => UserInteractor.processError(error));
     }


### PR DESCRIPTION
Fixes https://github.com/EatonGMBD/imp-central-impt/issues/17 (Allow multiple device IDs in impt device remove)

--device (-d) option of impt device remove command may be repeated several times to specify multiple devices.
For example, impt device remove -d 30000c2a690e1c66 -d 30000c2a690e1cf6 -d 30000c2a690e1ada

The details are described in CommandsManual.md.