### PR TITLE
ADO-260: impt: multiple device IDs in impt device restart

### DIFF
--- a/CommandsManual.md
+++ b/CommandsManual.md
@@ -968,14 +968,16 @@ impt device restart [--account <account_id>] --device <DEVICE_IDENTIFIER> [--con
     [--output <mode>] [--help]
 ```
 
-Reboots the specified device and, optionally, starts displaying logs from it.
+Reboots the specified devices and, optionally, starts displaying logs from them.
+
+It is not an atomic operation - it is possible for some of the specified devices to be restarted and other devices to fail to be restarted.
 
 | Option | Alias | Mandatory? | Value Required? | Description |
 | --- | --- | --- | --- | --- |
 | --account | -ac | No | Yes | The authenticated account identifier: an account ID |
-| --device | -d | Yes | Yes | A [device identifier](#device-identifier) |
+| --device | -d | Yes | Yes | A [device identifier](#device-identifier) of Device to be restarted. This option may be repeated multiple times to specify multiple Devices |
 | --conditional | -c | No | No | Trigger a conditional restart (see the impCentral API specification) |
-| --log | -l | No | No | Start displaying logs from the specified device (see [`impt log stream`](#log-stream)). To stop displaying the logs press *Ctrl-C*. Optional value specifies the [format of timestamps in the logs](#timestamp-format-in-logs) |
+| --log | -l | No | No | Start displaying logs from the specified devices (see [`impt log stream`](#log-stream)). To stop displaying the logs press *Ctrl-C*. Optional value specifies the [format of timestamps in the logs](#timestamp-format-in-logs) |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
 | --help | -h | No | No | Displays a description of the command. Ignores any other options |
 

--- a/bin/cmds/device/restart.js
+++ b/bin/cmds/device/restart.js
@@ -39,7 +39,11 @@ exports.describe = COMMAND_SHORT_DESCR;
 exports.builder = function (yargs) {
     const options = Options.getOptions({
         [Options.ACCOUNT] : false,
-        [Options.DEVICE_IDENTIFIER] : true,
+        [Options.DEVICE_IDENTIFIER] : {
+            demandOption : true,
+            type : 'array',
+            elemType : 'string'
+        },
         [Options.CONDITIONAL] : false,
         [Options.LOG] : {
             demandOption : false,

--- a/lib/Device.js
+++ b/lib/Device.js
@@ -194,26 +194,36 @@ class Device extends Entity {
     //                          restarted, or rejects with an error
     _restart(options) {
         options = options || new Options();
-        const conditional = options.conditional;
         return this.getEntityId().
-            then(() => this._helper.restart(this.id, conditional)).
-            then(() => UserInteractor.printInfo(
-                conditional ? UserInteractor.MESSAGES.DEVICE_COND_RESTARTED : UserInteractor.MESSAGES.DEVICE_RESTARTED,
-                this.identifierInfo));
+            then(() => this._helper.restart(this.id, options.conditional));
     }
 
-    // Reboots the Device or reports an error occurred.
+    // Reboots the Devices and, optionally, starts displaying logs from them.
     //
     // Parameters:
     //     options : Options    impt options of the corresponding command
     //
     // Returns:                 Nothing
     restart(options) {
-        this._restart(options).
+        let devices = options.deviceIdentifier.map(deviceId => new Device(options).initByIdentifier(deviceId));
+        this._helper.makeConcurrentOperations(devices, device => device.getEntity()).
             then(() => {
+                devices = Utils.getUniqueEntities(devices);
+                const unassignedDevices = devices.filter(device => !device.assigned);
+                if (unassignedDevices.length > 0) {
+                    return Promise.reject(new Errors.ImptError(
+                        UserInteractor.ERRORS.UNASSIGNED_DEVICES_RESTART,
+                        UserInteractor.getMultipleEntitiesInfo(unassignedDevices)));
+                }
+                return this._helper.makeConcurrentOperations(devices, device => device._restart(options));
+            }).
+            then(() => {
+                UserInteractor.printInfo(
+                    options.conditional ? UserInteractor.MESSAGES.DEVICE_COND_RESTARTED : UserInteractor.MESSAGES.DEVICE_RESTARTED,
+                    UserInteractor.getMultipleEntitiesInfo(devices));
                 if (options.log) {
                     const Log = require('./Log');
-                    new Log(options)._stream([this]);
+                    new Log(options)._stream(devices);
                 }
                 else {
                     UserInteractor.printResultWithStatus();

--- a/lib/util/UserInteractor.js
+++ b/lib/util/UserInteractor.js
@@ -254,6 +254,7 @@ const ERRORS = {
     DG_OLD_MIN_SUPPORTED_DEPLOYMENT : `${_MIN_SUPPORTED_DEPLOYMENT} cannot be set to an earlier ${_DEPLOYMENT} than the current ${_MIN_SUPPORTED_DEPLOYMENT}.`,
     BUILD_DELETE_ERR : `Impossible to delete %s. It is the ${_MIN_SUPPORTED_DEPLOYMENT} or newer for %s.`,
     BUILD_DEPLOY_FILE_NOT_FOUND : 'File with IMP %s source code "%s" is not found.',
+    UNASSIGNED_DEVICES_RESTART : '%s are unassigned, they cannot be restarted.',
     MULTIPLE_IDENTIFIERS_FOUND : 'Multiple %ss "%s" are found:',
     MULTIPLE_IDS_FOUND : 'Multiple %ss are found:',
     NO_IDENTIFIER : 'No %s Identifier is specified.',

--- a/spec/device/device_restart.spec.js
+++ b/spec/device/device_restart.spec.js
@@ -75,7 +75,7 @@ describe(`impt device restart test suite (output: ${outputMode ? outputMode : 'd
     function _checkSuccessRestartedDeviceMessage(commandOut, device) {
         ImptTestHelper.checkOutputMessage(`${outputMode}`, commandOut,
             Util.format(`${UserInterractor.MESSAGES.DEVICE_RESTARTED}`,
-                `${Identifier.ENTITY_TYPE.TYPE_DEVICE} "${device}"`)
+                `${Identifier.ENTITY_TYPE.TYPE_DEVICE}(s) "${device}"`)
         );
     }
 
@@ -83,7 +83,7 @@ describe(`impt device restart test suite (output: ${outputMode ? outputMode : 'd
     function _checkSuccessCondRestartedDeviceMessage(commandOut, device) {
         ImptTestHelper.checkOutputMessage(`${outputMode}`, commandOut,
             Util.format(`${UserInterractor.MESSAGES.DEVICE_COND_RESTARTED}`,
-                `${Identifier.ENTITY_TYPE.TYPE_DEVICE} "${device}"`)
+                `${Identifier.ENTITY_TYPE.TYPE_DEVICE}(s) "${device}"`)
         );
     }
 
@@ -118,6 +118,17 @@ describe(`impt device restart test suite (output: ${outputMode ? outputMode : 'd
         it('conditional restart device by agent id', (done) => {
             ImptTestHelper.runCommand(`impt device restart -c -d ${ImptTestHelper.deviceInfo.deviceAgentId} ${outputMode}`, (commandOut) => {
                 _checkSuccessCondRestartedDeviceMessage(commandOut, ImptTestHelper.deviceInfo.deviceAgentId);
+                ImptTestHelper.checkSuccessStatus(commandOut);
+            }).
+                then(done).
+                catch(error => done.fail(error));
+        });
+
+        it('restart multiple devices', (done) => {
+            const devices = Array(3).fill(config.devices[config.deviceidx]).
+                map((device) => `--device ${device}`).join(' ');
+            ImptTestHelper.runCommand(`impt device restart ${devices} ${outputMode}`, (commandOut) => {
+                _checkSuccessRestartedDeviceMessage(commandOut, config.devices[config.deviceidx]);
                 ImptTestHelper.checkSuccessStatus(commandOut);
             }).
                 then(done).


### PR DESCRIPTION
Fixes #21

--device (-d) option of `impt device restart` command may be repeated several times to specify multiple devices.
For example, `impt device restart -d 30000c2a690e1c66 -d 30000c2a690e1cf6 -d 30000c2a690e1ada`.

The details are described in CommandsManual.md.