### PR TITLE
Add `impt build generate` command for artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `impt dg restart`
   - `impt log stream`
   - `impt log get`
+- Added `impt build generate` to output reproducible artifacts to a build folder.
 
 ### Changed ###
 

--- a/CommandsManual.md
+++ b/CommandsManual.md
@@ -19,6 +19,7 @@
 **[impt build copy](#build-copy)**<br />
 **[impt build delete](#build-delete)**<br />
 **[impt build deploy](#build-deploy)**<br />
+**[impt build generate](#build-generate)**<br />
 **[impt build get](#build-get)**<br />
 **[impt build info](#build-info)**<br />
 **[impt build list](#build-list)**<br />
@@ -744,6 +745,30 @@ The new build is not run until the devices are rebooted. To run it, call [`impt 
 | --origin | -o | No | Yes | A free-form key to store a link to the code’s storage location, eg. a GitHub repo name or URL |
 | --tag | -t | No | Yes | A tag applied to this build (Deployment). This option may be repeated multiple times to apply multiple tags |
 | --flagged | -f | No | No | If `true` or no value, this build (Deployment) cannot be deleted without first setting this option back to `false`. If `false` or the option is not specified, the build can be deleted |
+| --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
+| --help | -h | No | No | Displays a description of the command. Ignores any other options |
+
+#### Build Generate ####
+
+```
+impt build generate [--account <account_id>] [--dg <DEVICE_GROUP_IDENTIFIER>]
+    [--device-file <device_file>] [--agent-file <agent_file>]
+    [--origin <origin>] [--output <mode>] [--help]
+```
+
+Generates a build artifact from the specified source files, and outputs the artifacts to the build folder.
+
+The command fails if one or both of the specified source files do not exist, or the specified Device Group does not exist. The Device Group Id is used to fetch device group specific settings from the Project File.
+
+No deployment is run as a part of this command, only the reusable assets are generated to the build folder.
+
+| Option | Alias | Mandatory? | Value Required? | Description |
+| --- | --- | --- | --- | --- |
+| --account | -ac | No | Yes | The authenticated account identifier: an account ID |
+| --dg | -g | Yes/[Project](#project-files) | Yes | A [Device Group identifier](#device-group-identifier). If not specified, the Device Group referenced by the [Project file](#project-files) in the current directory is used (if there is no Project file, the command fails) |
+| --device-file | -x | No | Yes | The device source code file name. If not specified, the file referenced by the [Project file](#project-files) in the current directory is used; if there is no Project file, empty code is used. If the specified file does not exist, the command fails |
+| --agent-file | -y | No | Yes | The agent source code file name. If not specified, the file referenced by the [Project file](#project-files) in the current directory is used; if there is no Project file, empty code is used. If the specified file does not exist, the command fails |
+| --origin | -o | No | Yes | A free-form key to store a link to the code’s storage location, eg. a GitHub repo name or URL |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
 | --help | -h | No | No | Displays a description of the command. Ignores any other options |
 

--- a/bin/cmds/build/generate.js
+++ b/bin/cmds/build/generate.js
@@ -1,0 +1,71 @@
+// MIT License
+//
+// Copyright 2018 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+'use strict';
+
+const Build = require('../../../lib/Build');
+const Options = require('../../../lib/util/Options');
+
+const COMMAND = 'generate';
+const COMMAND_SECTION = 'build';
+const COMMAND_SHORT_DESCR = 'Generates a build artifact.';
+const COMMAND_DESCRIPTION = 'Generates a build artifact from the specified source files,' +
+    ' and outputs the artifacts to the build folder.';
+
+exports.command = COMMAND;
+
+exports.describe = COMMAND_SHORT_DESCR;
+
+exports.builder = function (yargs) {
+    const options = Options.getOptions({
+        [Options.ACCOUNT] : false,
+        [Options.DEVICE_GROUP_IDENTIFIER] : false,
+        [Options.DEVICE_FILE] : {
+            demandOption : false,
+            describe : 'The device source code file name.' +
+                ' If not specified, the file referenced by the Project file in the current directory is used;' +
+                ' if there is no Project file, empty code is used. If the specified file does not exist, the command fails.'
+        },
+        [Options.AGENT_FILE] : {
+            demandOption : false,
+            describe : 'The agent source code file name.' +
+                ' If not specified, the file referenced by the Project file in the current directory is used;' +
+                ' if there is no Project file, empty code is used. If the specified file does not exist, the command fails.'
+        },
+        [Options.ORIGIN] : false,
+        [Options.OUTPUT] : false
+    });
+    return yargs
+        .usage(Options.getUsage(COMMAND_SECTION, COMMAND, COMMAND_DESCRIPTION, Options.getCommandOptions(options)))
+        .options(options)
+        .check(function (argv) {
+            return Options.checkOptions(argv, options);
+        })
+        .strict();
+};
+
+exports.handler = function (argv) {
+    const options = new Options(argv);
+    new Build(options).generate(options);
+};

--- a/lib/Build.js
+++ b/lib/Build.js
@@ -217,15 +217,7 @@ class Build extends Entity {
         return this._createEntity(deviceGroup.id, deviceGroup.type, attrs);
     }
 
-    // Creates a build from the specified source files, and deploys it to all Devices of the specified
-    // Device Group.
-    //
-    // Parameters:
-    //     options : Options    impt options of the corresponding command
-    //
-    // Returns:                 Promise that resolves when the Build is successfully deployed,
-    //                          or rejects with an error
-    _deploy(options) {
+    _createArtifact(options) {
         return this._setFileOptions(options).
             then(() => this._checkSourceFiles()).
             then((sources) => {
@@ -264,7 +256,6 @@ class Build extends Entity {
                     }
                 }
 
-                // build
                 Utils.makeDirSync("build");
                 this.setBuilderSaveFiles("agent");
                 sources.agentCode = this._Builder.machine.execute(
@@ -284,10 +275,38 @@ class Build extends Entity {
                         }
                     }
                 }
-
-                return this._create(options, sources.deviceCode, sources.agentCode);
-
+                
+                return Promise.resolve(sources);
             });
+    }
+
+    // Creates a build from the specified source files, and deploys it to all Devices of the specified
+    // Device Group.
+    //
+    // Parameters:
+    //     options : Options    impt options of the corresponding command
+    //
+    // Returns:                 Promise that resolves when the Build is successfully deployed,
+    //                          or rejects with an error
+    _deploy(options) {
+        return this._createArtifact(options).
+            then((sources) => {
+                return this._create(options, sources.deviceCode, sources.agentCode);
+            });
+    }
+    
+    // Generates a build artifact from the specified source files
+    //
+    // Parameters:
+    //     options : Options    impt options of the corresponding command
+    //
+    // Returns:                 Nothing
+    generate(options) {
+        this._createArtifact(options).
+            then(() => {
+                UserInteractor.printSuccessStatus()
+            }).
+            catch(error => UserInteractor.processError(error, this._agentFileName, this._deviceFileName));
     }
 
     // Creates a build from the specified source files, and deploys it to all Devices of the specified


### PR DESCRIPTION
The current implementation of `impt build deploy` combines the preBuild, build, postBuild, and deploy steps all into one. This makes it difficult to run in PR builds or CI builds to get a reproducible artifact. We also don't want to accidentally deploy to same DG in parallel for PR build validation.

This PR adds a command for `impt build generate` which will only run the preBuild, build, and postBuild steps, but not deploy the code to imp central. Generate command requires GitHub access token in order to pull the dependencies.

Future iterations of this may include a configurable output path for the assets to make it easier to bundle.

This PR should keep the current functionality of `impt build deploy` the same (but refactors out the common code).

Troubleshooting:
If running without `impt auth login` or a valid impt.auth file, you will need these environment variables set:

GITHUB_TOKEN=<VALID TOKEN>
IMPT_LOGINKEY='loginkey';
IMPT_USER='user';
IMPT_ENDPOINT='endpoint';

The IMPT variables can be kept as fake values since we are not actually talking to imp central when generating assets.
