### PR TITLE
Add save/use Builder artifacts options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] ##
 
+### Added ###
+
+- `--save-artifacts` and `--use-artifacts` options in:
+  - `impt build deploy`
+  - `impt build run`
+  - `impt build generate`
+
 ## [v3.0.1-etn] - 2020-08-13
 
 ### Fixed ###

--- a/CommandsManual.md
+++ b/CommandsManual.md
@@ -753,12 +753,16 @@ The user is asked to confirm the operation, unless confirmed automatically with 
 ```
 impt build deploy [--account <account_id>] [--all] [--dg <DEVICE_GROUP_IDENTIFIER>] [--device-file <device_file>]
     [--agent-file <agent_file>] [--descr <build_description>] [--origin <origin>]
-    [--tag <tag>] [--flagged [true|false]] [--output <mode>] [--help]
+    [--tag <tag>] [--flagged [true|false]]
+    [--save-artifacts] [--use-artifacts]
+    [--output <mode>] [--help]
 ```
 
 Creates a build (Deployment) from the specified source files, with a description (if specified) and attributes (if specified), and deploys it to all the devices assigned to the specified Device Group.
 
 The command fails if one or both of the specified source files do not exist, or the specified Device Group does not exist.
+
+[Builder](https://github.com/electricimp/Builder) is called to preprocess the source files before the Deployment creation.
 
 The new build is not run until the devices are rebooted. To run it, call [`impt dg restart`](#device-group-restart) or [`impt device restart`](#device-restart).
 
@@ -773,6 +777,8 @@ The new build is not run until the devices are rebooted. To run it, call [`impt 
 | --origin | -o | No | Yes | A free-form key to store a link to the code’s storage location, eg. a GitHub repo name or URL |
 | --tag | -t | No | Yes | A tag applied to this build (Deployment). This option may be repeated multiple times to apply multiple tags |
 | --flagged | -f | No | No | If `true` or no value, this build (Deployment) cannot be deleted without first setting this option back to `false`. If `false` or the option is not specified, the build can be deleted |
+| --save-artifacts | -sa | No | No | Save artifacts used by Builder to preprocess the source files. The artifacts are saved in the following files in the local directory: `build/dependencies.agent.json` (for references to the repository files used in the agent code), `build/dependencies.device.json` (for references to the repository files used in the device code), `build/directives.agent.json` (for Builder variable definitions used in the agent code), `build/directives.device.json` (for Builder variable definitions used in the device code). See [‘Builder: Reproducible Artifacts’](https://github.com/electricimp/Builder#reproducible-artifacts) |
+| --use-artifacts | -ua | No | No | Reuse the saved Builder artifacts to preprocess the source files. The artifacts are loaded from the following files (if exist) in the local directory: `build/dependencies.agent.json` (for references to the repository files used in the agent code), `build/dependencies.device.json` (for references to the repository files used in the device code), `build/directives.agent.json` (for Builder variable definitions used in the agent code), `build/directives.device.json` (for Builder variable definitions used in the device code). See [‘Builder: Reproducible Artifacts’](https://github.com/electricimp/Builder#reproducible-artifacts) |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
 | --help | -h | No | No | Displays a description of the command. Ignores any other options |
 
@@ -877,6 +883,7 @@ The returned list of the builds may be filtered. Filtering uses any combination 
 impt build run [--account <account_id] [--all] [--dg <DEVICE_GROUP_IDENTIFIER>] [--device-file <device_file>]
     [--agent-file <agent_file>] [--descr <build_description>]
     [--origin <origin>] [--tag <tag>] [--flagged [true|false]]
+    [--save-artifacts] [--use-artifacts]
     [--conditional] [--log [<timestamp_format>]] [--output <mode>] [--help]
 ```
 
@@ -885,6 +892,8 @@ Creates, deploys and runs a build (Deployment). Optionally, displays logs of the
 It behaves exactly like [`impt build deploy`](#build-deploy) followed by [`impt dg restart`](#device-group-restart) and, optionally, by [`impt log stream`](#log-stream).
 
 The command fails if one or both of the specified source files do not exist, or the specified Device Group does not exist. Informs the user if the specified Device Group does not have assigned devices; in this case, the Deployment is created anyway.
+
+[Builder](https://github.com/electricimp/Builder) is called to preprocess the source files before the Deployment creation.
 
 | Option | Alias | Mandatory? | Value Required? | Description |
 | --- | --- | --- | --- | --- |
@@ -897,6 +906,8 @@ The command fails if one or both of the specified source files do not exist, or 
 | --origin | -o | No | Yes | A free-form key to store the source location of the code |
 | --tag | -t | No | Yes | A tag applied to this build (Deployment). This option may be repeated multiple times to apply multiple tags |
 | --flagged | -f | No | No | If `true` or no value is supplied, this build (Deployment) cannot be deleted without first setting this option back to `false`. If `false` or the option is not specified, the build can be deleted |
+| --save-artifacts | -sa | No | No | Save artifacts used by Builder to preprocess the source files. The artifacts are saved in the following files in the local directory: `build/dependencies.agent.json` (for references to the repository files used in the agent code), `build/dependencies.device.json` (for references to the repository files used in the device code), `build/directives.agent.json` (for Builder variable definitions used in the agent code), `build/directives.device.json` (for Builder variable definitions used in the device code). See [‘Builder: Reproducible Artifacts’](https://github.com/electricimp/Builder#reproducible-artifacts) |
+| --use-artifacts | -ua | No | No | Reuse the saved Builder artifacts to preprocess the source files. The artifacts are loaded from the following files (if exist) in the local directory: `build/dependencies.agent.json` (for references to the repository files used in the agent code), `build/dependencies.device.json` (for references to the repository files used in the device code), `build/directives.agent.json` (for Builder variable definitions used in the agent code), `build/directives.device.json` (for Builder variable definitions used in the device code). See [‘Builder: Reproducible Artifacts’](https://github.com/electricimp/Builder#reproducible-artifacts) |
 | --conditional | -c | No | No | Trigger a conditional restart of the devices assigned to the specified Device Group instead of a normal restart (see the impCentral API specification) |
 | --log | -l | No | No | Starts displaying logs from the devices assigned to the specified Device Group (see the [`impt log stream`](#log-stream) description). To stop displaying the logs, press *Ctrl-C*. Optional value specifies the [format of timestamps in the logs](#timestamp-format-in-logs) |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
@@ -1993,8 +2004,10 @@ Updates the specified webhook with a new target URL and/or MIME content-type. Fa
 | -q | --confirmed |
 | -r | --azure-repos-config, --create-target, --remove-tag, --remove, --region |
 | -s | --descr, --sha, --page-size, --stop-on-fail |
+| -sa | --save-artifacts |
 | -t | --tag, --timeout, --temp, --target, --to, --tests |
 | -u | --user, --full, --unflagged, --unflag, --unassigned, --unbond, --url, --dut |
+| -ua | --use-artifacts |
 | -v | --version |
 | -w | --wh, --pwd, --create-dut |
 | -x | --device-file |

--- a/CommandsManual.md
+++ b/CommandsManual.md
@@ -787,7 +787,8 @@ The new build is not run until the devices are rebooted. To run it, call [`impt 
 ```
 impt build generate [--account <account_id>] [--dg <DEVICE_GROUP_IDENTIFIER>]
     [--device-file <device_file>] [--agent-file <agent_file>]
-    [--origin <origin>] [--output <mode>] [--help]
+    [--origin <origin>] [--save-artifacts] [--use-artifacts]
+    [--output <mode>] [--help]
 ```
 
 Generates a build artifact from the specified source files, and outputs the artifacts to the build folder.
@@ -803,6 +804,8 @@ No deployment is run as a part of this command, only the reusable assets are gen
 | --device-file | -x | No | Yes | The device source code file name. If not specified, the file referenced by the [Project file](#project-files) in the current directory is used; if there is no Project file, empty code is used. If the specified file does not exist, the command fails |
 | --agent-file | -y | No | Yes | The agent source code file name. If not specified, the file referenced by the [Project file](#project-files) in the current directory is used; if there is no Project file, empty code is used. If the specified file does not exist, the command fails |
 | --origin | -o | No | Yes | A free-form key to store a link to the code’s storage location, eg. a GitHub repo name or URL |
+| --save-artifacts | -sa | No | No | Save artifacts used by Builder to preprocess the source files. The artifacts are saved in the following files in the local directory: `build/dependencies.agent.json` (for references to the repository files used in the agent code), `build/dependencies.device.json` (for references to the repository files used in the device code), `build/directives.agent.json` (for Builder variable definitions used in the agent code), `build/directives.device.json` (for Builder variable definitions used in the device code). See [‘Builder: Reproducible Artifacts’](https://github.com/electricimp/Builder#reproducible-artifacts) |
+| --use-artifacts | -ua | No | No | Reuse the saved Builder artifacts to preprocess the source files. The artifacts are loaded from the following files (if exist) in the local directory: `build/dependencies.agent.json` (for references to the repository files used in the agent code), `build/dependencies.device.json` (for references to the repository files used in the device code), `build/directives.agent.json` (for Builder variable definitions used in the agent code), `build/directives.device.json` (for Builder variable definitions used in the device code). See [‘Builder: Reproducible Artifacts’](https://github.com/electricimp/Builder#reproducible-artifacts) |
 | --output | -z | No | Yes | Adjusts the [command’s output](#command-output) |
 | --help | -h | No | No | Displays a description of the command. Ignores any other options |
 

--- a/bin/cmds/build/deploy.js
+++ b/bin/cmds/build/deploy.js
@@ -66,6 +66,8 @@ exports.builder = function (yargs) {
             demandOption : false,
             describe : 'Run build for all device groups in project file.'
         },
+        [Options.SAVE_ARTIFACTS] : false,
+        [Options.USE_ARTIFACTS] : false,
         [Options.OUTPUT] : false
     });
     return yargs

--- a/bin/cmds/build/generate.js
+++ b/bin/cmds/build/generate.js
@@ -54,6 +54,8 @@ exports.builder = function (yargs) {
                 ' if there is no Project file, empty code is used. If the specified file does not exist, the command fails.'
         },
         [Options.ORIGIN] : false,
+        [Options.SAVE_ARTIFACTS] : false,
+        [Options.USE_ARTIFACTS] : false,
         [Options.OUTPUT] : false
     });
     return yargs

--- a/bin/cmds/build/run.js
+++ b/bin/cmds/build/run.js
@@ -60,6 +60,8 @@ exports.builder = function (yargs) {
         [Options.ORIGIN] : false,
         [Options.TAG] : false,
         [Options.FLAGGED] : false,
+        [Options.SAVE_ARTIFACTS] : false,
+        [Options.USE_ARTIFACTS] : false,
         [Options.CONDITIONAL] : {
             demandOption : false,
             describe : 'Trigger a conditional restart of the devices assigned to the specified Device Group instead of a normal restart.'

--- a/lib/Build.js
+++ b/lib/Build.js
@@ -110,9 +110,15 @@ class Build extends Entity {
         this._builderVariables = value;
     }
 
-    setBuilderSaveFiles(type) {
-        this._Builder.machine.dependenciesSaveFile = `build/dependencies.${type}.json`;
-        this._Builder.machine.directivesSaveFile = `build/directives.${type}.json`;
+    setBuilderSaveFiles(type, options) {
+        if (options.saveArtifacts) {
+            this._Builder.machine.dependenciesSaveFile = `build/dependencies.${type}.json`;
+            this._Builder.machine.directivesSaveFile = `build/directives.${type}.json`;
+        }
+        if (options.useArtifacts) {
+            this._Builder.machine.dependenciesUseFile = `build/dependencies.${type}.json`;
+            this._Builder.machine.directivesUseFile = `build/directives.${type}.json`;
+        }
     }
 
     renameSaveFiles(deploymentId) {
@@ -265,12 +271,12 @@ class Build extends Entity {
                 }
 
                 Utils.makeDirSync("build");
-                this.setBuilderSaveFiles("agent");
+                this.setBuilderSaveFiles("agent", options);
                 sources.agentCode = this._Builder.machine.execute(
                     sources.agentCode ? `@include "${sources.agentCode}"` : "", newBuilder["variables"]);
                 Utils.writeFile("build/agentCode.nut", sources.agentCode);
 
-                this.setBuilderSaveFiles("device");
+                this.setBuilderSaveFiles("device", options);
                 sources.deviceCode = this._Builder.machine.execute(
                     sources.deviceCode ? `@include "${sources.deviceCode}"` : "", newBuilder["variables"]);
                 Utils.writeFile("build/deviceCode.nut", sources.deviceCode);
@@ -334,7 +340,6 @@ class Build extends Entity {
             this._deploy(options).
                 then(() => this._collectShortListData()).
                 then(() => {
-                    this.renameSaveFiles(this._displayData.Deployment.id)
                     UserInteractor.printResultWithStatus(this._displayData)
                 }).
                 catch(error => UserInteractor.processError(error, this._agentFileName, this._deviceFileName));
@@ -358,7 +363,6 @@ class Build extends Entity {
             const deviceGroup = new DeviceGroup(options);
             this._deploy(options).
             then(() => {
-                this.renameSaveFiles(this.apiEntity.id);
                 return deviceGroup._restart(options);
             }).
             then(() => {

--- a/lib/util/Options.js
+++ b/lib/util/Options.js
@@ -785,6 +785,20 @@ class Options {
                 requiresArg : true,
                 _usage: '<tag>'
             },
+            [Options.SAVE_ARTIFACTS] : {
+                describe: 'Save artifacts used by Builder to preprocess the source files.' +
+                    ' The artifacts are saved in the following files in the local directory:' +
+                    ' build/dependencies.agent.json (for references to the repository files used in the agent code),' +
+                    ' build/dependencies.device.json (for references to the repository files used in the device code),' +
+                    ' build/directives.agent.json (for Builder variable definitions used in the agent code),' +
+                    ' build/directives.device.json (for Builder variable definitions used in the device code).',
+                alias: 'sa',
+                nargs: 0,
+                type : 'boolean',
+                noValue: true,
+                default: undefined,
+                _usage: ''
+            },
             [Options.SHA] : {
                 describe: 'Lists builds with the specified SHA only.',
                 alias: 's',
@@ -915,6 +929,20 @@ class Options {
                 type : 'string',
                 requiresArg : true,
                 _usage: '<target_url>'
+            },
+            [Options.USE_ARTIFACTS] : {
+                describe: 'Reuse the saved Builder artifacts to preprocess the source files.' +
+                    ' The artifacts are loaded from the following files (if exist) in the local directory:' +
+                    ' build/dependencies.agent.json (for references to the repository files used in the agent code),' +
+                    ' build/dependencies.device.json (for references to the repository files used in the device code),' +
+                    ' build/directives.agent.json (for Builder variable definitions used in the agent code),' +
+                    ' build/directives.device.json (for Builder variable definitions used in the device code).',
+                alias: 'ua',
+                nargs: 0,
+                type : 'boolean',
+                noValue: true,
+                default: undefined,
+                _usage: ''
             },
             [Options.USER] : {
                 describe: 'The account identifier: a username or an email address.',
@@ -1521,6 +1549,14 @@ class Options {
         return this._options[Options.REMOVE_TAG];
     }
 
+    static get SAVE_ARTIFACTS() {
+        return 'save-artifacts';
+    }
+
+    get saveArtifacts() {
+        return this._options[Options.SAVE_ARTIFACTS];
+    }
+
     static get SHA() {
         return 'sha';
     }
@@ -1639,6 +1675,14 @@ class Options {
 
     get url() {
         return this._options[Options.URL];
+    }
+
+    static get USE_ARTIFACTS() {
+        return 'use-artifacts';
+    }
+
+    get useArtifacts() {
+        return this._options[Options.USE_ARTIFACTS];
     }
 
     static get USER() {


### PR DESCRIPTION
--save-artifacts and --use-artifacts options added to:
- impt build deploy
- impt build run
- impt build generate

The details are described in CommandsManual.md.

For simplicity, artifacts are saved/loaded to/from files with default names. Specifying of custom names is not supported.