### PR TITLE
Full support for post (device) build step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ bin/cmds/.DS_Store
 .impt.auth
 
 .vscode
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] ##
 
+### Added ###
+
+- a `postDeviceBuild` step (similar to `preBuild`) for post processing the built
+  device code (used in tests also).
+
 ## [v3.1.0-etn] - 2020-09-01
 
 ### Added ###
@@ -28,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update Builder dependency to [EI-hosted v4.0.0](https://github.com/electricimp/Builder/releases/tag/4.0.0)
 - `impt build generate` command to output reproducible artifacts to a build folder
-- Setting of User-defined Environment Variables in `impt dg create` and `impt dg update` commands 
+- Setting of User-defined Environment Variables in `impt dg create` and `impt dg update` commands
 - Support for ADO Repos as a file source for Builder. Includes:
   - `impt auth azure-repos` command
   - `impt test azure-repos` command
@@ -60,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - "global-agent" NodeJS module is used for logs streaming over proxy
 - "yargs" NodeJS module version 10.0.3 is required for processing entity IDs which start with "-"
 - Logs are colorized (similar to impCentral IDE) in the default and "debug" output modes
-- If logs are streamed from one device only, Device Id is not displayed in logs in the default and "minimal" output modes 
+- If logs are streamed from one device only, Device Id is not displayed in logs in the default and "minimal" output modes
 - `--device` (`-d`) option may be repeated several times to specify multiple devices in the following commands:
   - `impt device assign`
   - `impt device unassign`

--- a/CommandsManual.md
+++ b/CommandsManual.md
@@ -382,7 +382,12 @@ Each project file contains the following:
 - Global Builder section: includes:
     - `variables` which are used by all device groups.
     - `libs` which are `.js` files that contain some functions used by builder variables.
-    - `preBuild` and `postBuild` which are commands or `.js` files that are executed before and after building the code.
+    - `preBuild` which is an array of shell commands that are executed before bulding the code.
+    - `postDeviceBuild` which is an array of shell commands that are executed
+      after building the device code (including when running tests). The path of
+      the source code file to be post-processed is available to be interpolated
+      with `${DEVICE_CODE_PATH}` like this: `"postDeviceBuild": ["processFile.sh
+      ${DEVICE_CODE_PATH}"],`
 - Device Groups: Each device group is a key-value pair where the key is the device group ID and the value is an object containing the following information:
     - `endpoint`: an impCentral API endpoint (the API base URL).
     - `accountID`: the account ID that the device group belongs to.
@@ -425,9 +430,9 @@ The project file is of the form:
             "node prebuild1.js",
             "echo 'prebuild2'"
         ],
-        "postBuild": [
-            "echo 'postbuild1'",
-            "echo 'postbuild2'"
+        "postDeviceBuild": [
+            "echo 'postbuild1: ${DEVICE_CODE_PATH}'",
+            "echo 'postbuild2: ${DEVICE_CODE_PATH}'"
         ]
       },
       "isDefault": true
@@ -446,9 +451,9 @@ The project file is of the form:
             "node prebuild1.js",
             "echo 'prebuild2'"
         ],
-        "postBuild": [
-            "echo 'postbuild1'",
-            "echo 'postbuild2'"
+        "postDeviceBuild": [
+            "echo 'postbuild1: ${DEVICE_CODE_PATH}'",
+            "echo 'postbuild2: ${DEVICE_CODE_PATH}'"
         ]
       }
     }

--- a/lib/Build.js
+++ b/lib/Build.js
@@ -234,7 +234,7 @@ class Build extends Entity {
     _createArtifact(options) {
         return this._setFileOptions(options).
             then(() => this._checkSourceFiles()).
-            then((sources) => {
+            then(async (sources) => {
                 var projectBuilder;
                 var secretBuilder;
                 var newBuilder;
@@ -271,15 +271,17 @@ class Build extends Entity {
                 }
 
                 Utils.makeDirSync("build");
+
                 this.setBuilderSaveFiles("agent", options);
                 sources.agentCode = this._Builder.machine.execute(
                     sources.agentCode ? `@include "${sources.agentCode}"` : "", newBuilder["variables"]);
-                Utils.writeFile("build/agentCode.nut", sources.agentCode);
+                await Utils.writeFile("build/agentCode.nut", sources.agentCode);
 
                 this.setBuilderSaveFiles("device", options);
                 sources.deviceCode = this._Builder.machine.execute(
                     sources.deviceCode ? `@include "${sources.deviceCode}"` : "", newBuilder["variables"]);
-                Utils.writeFile("build/deviceCode.nut", sources.deviceCode);
+                await Utils.writeFile("build/deviceCode.nut", sources.deviceCode);
+
 
                 // execute the post-build commands
                 if (newBuilder["postBuild"]) {
@@ -290,7 +292,11 @@ class Build extends Entity {
                     }
                 }
 
-                return Promise.resolve(sources);
+                return {
+                    ...sources,
+                    agentCode: Utils.readFileSync("build/agentCode.nut"),
+                    deviceCode: Utils.readFileSync("build/deviceCode.nut"),
+                };
             });
     }
 

--- a/lib/Build.js
+++ b/lib/Build.js
@@ -265,7 +265,7 @@ class Build extends Entity {
                 }
                 newBuilder = newBuilder || {};
 
-                BuilderLifecycle.executeCommands(newBuilder["preBuild"]);
+                BuilderLifecycle.executeCommands("preBuild", newBuilder["preBuild"]);
 
                 Utils.makeDirSync("build");
 
@@ -279,7 +279,7 @@ class Build extends Entity {
                     sources.deviceCode ? `@include "${sources.deviceCode}"` : "", newBuilder["variables"]);
                 await Utils.writeFile(DEVICE_BUILD_FILE, sources.deviceCode);
 
-                BuilderLifecycle.executeCommands(newBuilder["postDeviceBuild"], {
+                BuilderLifecycle.executeCommands("postDeviceBuild", newBuilder["postDeviceBuild"], {
                     DEVICE_CODE_PATH: DEVICE_BUILD_FILE,
                 });
 

--- a/lib/Build.js
+++ b/lib/Build.js
@@ -56,6 +56,9 @@ const ATTR_DEVICE_CODE = 'device_code';
 const ATTR_AGENT_CODE = 'agent_code';
 const ATTR_CREATED_AT = 'created_at';
 
+const AGENT_BUILD_FILE = "build/agentCode.nut";
+const DEVICE_BUILD_FILE = "build/deviceCode.nut";
+
 // This class represents Deployment impCentral API entity.
 // Provides methods used by impt Build Manipulation Commands.
 class Build extends Entity {
@@ -269,21 +272,21 @@ class Build extends Entity {
                 this.setBuilderSaveFiles("agent", options);
                 sources.agentCode = this._Builder.machine.execute(
                     sources.agentCode ? `@include "${sources.agentCode}"` : "", newBuilder["variables"]);
-                await Utils.writeFile("build/agentCode.nut", sources.agentCode);
+                await Utils.writeFile(AGENT_BUILD_FILE, sources.agentCode);
 
                 this.setBuilderSaveFiles("device", options);
                 sources.deviceCode = this._Builder.machine.execute(
                     sources.deviceCode ? `@include "${sources.deviceCode}"` : "", newBuilder["variables"]);
-                await Utils.writeFile("build/deviceCode.nut", sources.deviceCode);
+                await Utils.writeFile(DEVICE_BUILD_FILE, sources.deviceCode);
 
                 BuilderLifecycle.executeCommands(newBuilder["postDeviceBuild"], {
-                    DEVICE_CODE_PATH: "build/deviceCode.nut",
+                    DEVICE_CODE_PATH: DEVICE_BUILD_FILE,
                 });
 
                 return {
                     ...sources,
-                    agentCode: Utils.readFileSync("build/agentCode.nut"),
-                    deviceCode: Utils.readFileSync("build/deviceCode.nut"),
+                    agentCode: Utils.readFileSync(AGENT_BUILD_FILE),
+                    deviceCode: Utils.readFileSync(DEVICE_BUILD_FILE),
                 };
             });
     }

--- a/lib/Build.js
+++ b/lib/Build.js
@@ -44,8 +44,9 @@ const Account = require('./Account');
 const BuilderConfig = require('./util/BuilderConfig');
 const ProjectConfig = require('./util/ProjectConfig');
 const Builder = require('Builder');
+const BuilderLifecycle = require('./util/BuilderLifecycle');
 const deepmerge = require('deepmerge');
-const Shell = require('shelljs');
+
 
 const ATTR_SHA = 'sha';
 const ATTR_TAGS = 'tags';
@@ -261,14 +262,7 @@ class Build extends Entity {
                 }
                 newBuilder = newBuilder || {};
 
-                // execute the pre-build commands
-                if (newBuilder["preBuild"]) {
-                    for (var command of newBuilder["preBuild"]) {
-                        if (Shell.exec(command).code !== 0) {
-                            UserInteractor.processError({message: "Pre-build command failure."})
-                        }
-                    }
-                }
+                BuilderLifecycle.executeCommands(newBuilder["preBuild"]);
 
                 Utils.makeDirSync("build");
 
@@ -282,16 +276,9 @@ class Build extends Entity {
                     sources.deviceCode ? `@include "${sources.deviceCode}"` : "", newBuilder["variables"]);
                 await Utils.writeFile("build/deviceCode.nut", sources.deviceCode);
 
-
-                // execute the device code post-build commands
-                if (newBuilder["postDeviceBuild"]) {
-                    for (var command of newBuilder["postDeviceBuild"]) {
-                        const cmd = command.replace(/\${DEVICE_CODE_PATH}/g, "build/deviceCode.nut");
-                        if (Shell.exec(cmd).code !== 0) {
-                            UserInteractor.processError({message: "Post-build command failure."})
-                        }
-                    }
-                }
+                BuilderLifecycle.executeCommands(newBuilder["postDeviceBuild"], {
+                    DEVICE_CODE_PATH: "build/deviceCode.nut",
+                });
 
                 return {
                     ...sources,

--- a/lib/Build.js
+++ b/lib/Build.js
@@ -283,10 +283,11 @@ class Build extends Entity {
                 await Utils.writeFile("build/deviceCode.nut", sources.deviceCode);
 
 
-                // execute the post-build commands
-                if (newBuilder["postBuild"]) {
-                    for (var command of newBuilder["postBuild"]) {
-                        if (Shell.exec(command).code !== 0) {
+                // execute the device code post-build commands
+                if (newBuilder["postDeviceBuild"]) {
+                    for (var command of newBuilder["postDeviceBuild"]) {
+                        const cmd = command.replace(/\${DEVICE_CODE_PATH}/g, "build/deviceCode.nut");
+                        if (Shell.exec(cmd).code !== 0) {
                             UserInteractor.processError({message: "Post-build command failure."})
                         }
                     }

--- a/lib/util/BuilderLifecycle.js
+++ b/lib/util/BuilderLifecycle.js
@@ -1,7 +1,7 @@
 const Shell = require('shelljs');
 const UserInteractor = require('./UserInteractor');
 
-function executeCommands(commands, commandVariables = {}) {
+function executeCommands(label, commands, commandVariables = {}) {
     if (!commands || commands.length == 0) {
         return;
     }
@@ -11,7 +11,7 @@ function executeCommands(commands, commandVariables = {}) {
             return str.replace(new RegExp(`\\\${${variable}}`, RegExp.global), commandVariables[variable]);
         }, command);
         if (Shell.exec(finalCommand).code !== 0) {
-            UserInteractor.processError({message: "Post-build command failure."})
+            UserInteractor.processError({message: `${label} lifecycle command failure (${command}).`})
         }
     }
 }

--- a/lib/util/BuilderLifecycle.js
+++ b/lib/util/BuilderLifecycle.js
@@ -1,0 +1,23 @@
+const Shell = require('shelljs');
+const UserInteractor = require('./UserInteractor');
+
+function executeCommands(commands, commandVariables = {}) {
+    if (!commands || commands.length == 0) {
+        return;
+    }
+
+    for (var command of commands) {
+        const finalCommand = Object.keys(commandVariables).reduce((str, variable) => {
+            return str.replace(new RegExp(`\\\${${variable}}`, RegExp.global), commandVariables[variable]);
+        }, command);
+        if (Shell.exec(finalCommand).code !== 0) {
+            UserInteractor.processError({message: "Post-build command failure."})
+        }
+    }
+}
+
+const BuilderLifecycle = {
+    executeCommands,
+};
+
+module.exports = BuilderLifecycle;

--- a/lib/util/TestHelper.js
+++ b/lib/util/TestHelper.js
@@ -76,7 +76,7 @@ class TestHelper {
     constructor(deviceGroup, options) {
         this._helper = ImpCentralApiHelper.getEntity();
         this._testConfig = TestConfig.getEntity();
-        this._projectConfig = ProjectConfig.getEntity(options);
+        this._projectConfig = new ProjectConfig({ ...options, deviceGroupIdentifier: deviceGroup.id });
         this._deviceGroup = deviceGroup;
         this._devices = null;
         this._success = true;
@@ -539,18 +539,30 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
             }
         }
 
+
         // Device code post processing
-        if (this._projectConfig.exists() && this._projectConfig.builderJSON["postDeviceBuild"]) {
-            const path = await Utils.writeToTempFile(deviceCode);
+        if (this._projectConfig.exists()) {
+            var localBuilderJSON;
             try {
-                BuilderLifecycle.executeCommands(this._projectConfig.builderJSON["postDeviceBuild"], {
-                    DEVICE_CODE_PATH: path,
-                });
-                deviceCode = await Utils.readFile(path);
-            } finally {
-                await Utils.deleteFile(path);
+                localBuilderJSON = this._projectConfig.localBuilderJSON;
+            } catch (err) {
+                // It's OK if there's no .impt.project entry for this specific DG
+            }
+
+            var builderConfig = deepmerge(this._projectConfig.builderJSON || {}, localBuilderJSON || {});
+            if (builderConfig.postDeviceBuild) {
+                const path = await Utils.writeToTempFile(deviceCode);
+                try {
+                    BuilderLifecycle.executeCommands(builderConfig.postDeviceBuild, {
+                        DEVICE_CODE_PATH: path,
+                    });
+                    deviceCode = await Utils.readFile(path);
+                } finally {
+                    await Utils.deleteFile(path);
+                }
             }
         }
+
 
         if (this.debug) {
             const Test = require('../Test');

--- a/lib/util/TestHelper.js
+++ b/lib/util/TestHelper.js
@@ -553,7 +553,7 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
             if (builderConfig.postDeviceBuild) {
                 const path = await Utils.writeToTempFile(deviceCode);
                 try {
-                    BuilderLifecycle.executeCommands(builderConfig.postDeviceBuild, {
+                    BuilderLifecycle.executeCommands("postDeviceBuild", builderConfig.postDeviceBuild, {
                         DEVICE_CODE_PATH: path,
                     });
                     deviceCode = await Utils.readFile(path);

--- a/lib/util/TestHelper.js
+++ b/lib/util/TestHelper.js
@@ -40,7 +40,7 @@ const sprintf = require('sprintf-js').sprintf;
 const TestDebugMixin = require('./TestDebugMixin');
 const randomWords = require('random-words');
 const ImpCentralApi = require('imp-central-api');
-const Shell = require('shelljs');
+const BuilderLifecycle = require('./BuilderLifecycle');
 
 const Util = require('util');
 const ImpCentralApiHelper = require('./ImpCentralApiHelper');
@@ -543,12 +543,9 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
         if (this._projectConfig.exists() && this._projectConfig.builderJSON["postDeviceBuild"]) {
             const path = await Utils.writeToTempFile(deviceCode);
             try {
-                for (var command of this._projectConfig.builderJSON["postDeviceBuild"]) {
-                    const cmd = command.replace(/\${DEVICE_CODE_PATH}/g, path);
-                    if (Shell.exec(cmd).code !== 0) {
-                        throw new Error("Post build command failure");
-                    }
-                }
+                BuilderLifecycle.executeCommands(this._projectConfig.builderJSON["postDeviceBuild"], {
+                    DEVICE_CODE_PATH: path,
+                });
                 deviceCode = await Utils.readFile(path);
             } finally {
                 await Utils.deleteFile(path);

--- a/lib/util/TestHelper.js
+++ b/lib/util/TestHelper.js
@@ -40,6 +40,7 @@ const sprintf = require('sprintf-js').sprintf;
 const TestDebugMixin = require('./TestDebugMixin');
 const randomWords = require('random-words');
 const ImpCentralApi = require('imp-central-api');
+const Shell = require('shelljs');
 
 const Util = require('util');
 const ImpCentralApiHelper = require('./ImpCentralApiHelper');
@@ -49,8 +50,10 @@ const GithubConfig = require('./GithubConfig');
 const BitbucketSrvConfig = require('./BitbucketSrvConfig');
 const AzureReposConfig = require('./AzureReposConfig');
 const BuilderConfig = require('./BuilderConfig');
+const ProjectConfig = require('./ProjectConfig');
 const Device = require('../Device');
 const Build = require('../Build');
+const Utils = require('./Utils');
 
 // Delay before testing start.
 // Prevents log sessions mixing, allows
@@ -73,6 +76,7 @@ class TestHelper {
     constructor(deviceGroup, options) {
         this._helper = ImpCentralApiHelper.getEntity();
         this._testConfig = TestConfig.getEntity();
+        this._projectConfig = ProjectConfig.getEntity(options);
         this._deviceGroup = deviceGroup;
         this._devices = null;
         this._success = true;
@@ -217,11 +221,11 @@ class TestHelper {
             });
     }
 
-    _runTestOnDeviceGroup(testFile) {
+    async _runTestOnDeviceGroup(testFile) {
         let deviceIndex = 0;
         this._sessionId = randomWords(2).join('-');
         // create agent/device code to run
-        const code = this._getSessionCode(testFile);
+        const code = await this._getSessionCode(testFile);
 
         if (code == null) {
             this._info(Util.format(UserInteractor.MESSAGES.TEST_SKIP_FILE, testFile.name));
@@ -247,7 +251,7 @@ class TestHelper {
     }
 
     _runTestOnDevice(device, deviceIndex, testFile) {
-        return new Promise((resolve, reject) => {
+        return new Promise(async (resolve, reject) => {
 
             // blank line
             this._blank();
@@ -271,7 +275,7 @@ class TestHelper {
             }
 
             // create agent/device code to run
-            const code = this._getSessionCode(testFile);
+            const code = await this._getSessionCode(testFile);
 
             if (code == null) {
                 this._info(Util.format(UserInteractor.MESSAGES.TEST_SKIP_FILE, testFile.name));
@@ -398,7 +402,7 @@ class TestHelper {
     }
 
     // Prepare source code
-    _getSessionCode(testFile) {
+    async _getSessionCode(testFile) {
         let agentCode, deviceCode;
 
         // save current test file name
@@ -532,6 +536,22 @@ ${'partnerpath' in testFile ? '@include "' + backslashToSlash(testFile.partnerpa
             if (code2Check.search(re) < 0) {
                 // skip this test
                 return null;
+            }
+        }
+
+        // Device code post processing
+        if (this._projectConfig.exists() && this._projectConfig.builderJSON["postDeviceBuild"]) {
+            const path = await Utils.writeToTempFile(deviceCode);
+            try {
+                for (var command of this._projectConfig.builderJSON["postDeviceBuild"]) {
+                    const cmd = command.replace(/\${DEVICE_CODE_PATH}/g, path);
+                    if (Shell.exec(cmd).code !== 0) {
+                        throw new Error("Post build command failure");
+                    }
+                }
+                deviceCode = await Utils.readFile(path);
+            } finally {
+                await Utils.deleteFile(path);
             }
         }
 

--- a/lib/util/Utils.js
+++ b/lib/util/Utils.js
@@ -26,6 +26,7 @@
 
 const Errors = require('./Errors');
 const FS = require('fs');
+const Tmp = require('tmp');
 
 // Helper class for File I/O operations and other utility methods
 class Utils {
@@ -166,6 +167,19 @@ class Utils {
             result.push(entity);
         }
         return result;
+    }
+
+    static writeToTempFile(content) {
+        return new Promise((resolve, reject) => {
+            Tmp.file(async function (err, path) {
+                if (err) {
+                    reject(err);
+                }
+
+                await Utils.writeFile(path, content);
+                resolve(path);
+            });
+        });
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1211,6 +1211,14 @@
         "path-parse": "^1.0.6"
       }
     },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
     "roarr": {
       "version": "2.15.3",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.3.tgz",
@@ -1347,6 +1355,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+    },
+    "tmp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+      "requires": {
+        "rimraf": "^3.0.0"
+      }
     },
     "tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "randomstring": "^1.1.3",
     "shelljs": "^0.8.3",
     "sprintf-js": "^1.0.3",
+    "tmp": "^0.2.1",
     "yargs": "10.0.3"
   },
   "scripts": {


### PR DESCRIPTION
* Changed `postBuild` to `postDeviceBuild` (as of now no plans to post-process agent code the same way)
* Updated test runner to look in the `.impt.project` for a `postDeviceBuild` either in the global config, or the DG specific config that corresponds to the DG specified in `.impt.test`.
* In the `postDeviceBuild` command it's possible to interpolate the path of the generated file using `${DEVICE_CODE_PATH}`