### PR TITLE
Update the impUnit git submodule to point to develop

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "lib/impUnit"]
 	path = lib/impUnit
 	url = https://github.com/electricimp/impUnit.git
+	branch = develop
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - a `postDeviceBuild` step (similar to `preBuild`) for post processing the built
   device code (used in tests also).
 
+### Fixed ###
+
+- Updated to an unreleased version of impUnit that contains the following:
+  - assertDeepEqual now works with blobs
+  - fixed a bug in the path that assertDeepEqual displays when there's a failure
+
 ## [v3.1.0-etn] - 2020-09-01
 
 ### Added ###


### PR DESCRIPTION
ElectricImp merged in a PR from Max that adds support to
assertDeepEquals for blobs. That change is on develop but has not been
released in a new version.

This commit changes the git submodule to point to the merge commit on
impUnit develop so we can include that change in our version of impt.